### PR TITLE
Add link to Angular Diagram component in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 A quick start Angular project that shows how to customize the diagram canvas page in the [Angular Diagram](https://www.syncfusion.com/angular-components/angular-diagram) component. This project includes code snippets for displaying page breaks and multiple pages in the canvas. It also includes code snippets for customizing the appearance of nodes and connectors and for bridging connectors.
 
-Refer to the node documentation for the Syncfusion&reg; Angular Diagram component: 
+Refer to the node documentation for the Angular Diagram component: 
 https://ej2.syncfusion.com/angular/documentation/diagram/nodes
 
-Refer to the connector documentation for the Syncfusion&reg; Angular Diagram component: 
+Refer to the connector documentation for the Angular Diagram component: 
 https://ej2.syncfusion.com/angular/documentation/diagram/connectors
 
-Refer to the page settings documentation for the Syncfusion&reg; Angular Diagram component: 
+Refer to the page settings documentation for the Angular Diagram component: 
 https://ej2.syncfusion.com/angular/documentation/diagram/page-settings
 
-Refer to the grid lines documentation for the Syncfusion&reg; Angular Diagram component: 
+Refer to the grid lines documentation for the Angular Diagram component: 
 https://ej2.syncfusion.com/angular/documentation/diagram/grid-lines
 
 ## Project prerequisites

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # How to Customize the Angular Diagram and Its Elements
 
-A quick start Angular project that shows how to customize the diagram canvas page in the Angular Diagram component. This project includes code snippets for displaying page breaks and multiple pages in the canvas. It also includes code snippets for customizing the appearance of nodes and connectors and for bridging connectors.
+A quick start Angular project that shows how to customize the diagram canvas page in the [Angular Diagram](https://www.syncfusion.com/angular-components/angular-diagram) component. This project includes code snippets for displaying page breaks and multiple pages in the canvas. It also includes code snippets for customizing the appearance of nodes and connectors and for bridging connectors.
 
 Refer to the node documentation for the Syncfusion&reg; Angular Diagram component: 
 https://ej2.syncfusion.com/angular/documentation/diagram/nodes


### PR DESCRIPTION
Updated README to include a link to the Angular Diagram component.